### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opera-devtools-mcp",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opera-devtools-mcp",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "bin": {
         "opera-devtools": "build/src/bin/opera-devtools.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opera-devtools-mcp",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "MCP server for Opera DevTools",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/operasoftware/opera-devtools-mcp",
     "source": "github"
   },
-  "version": "0.2.6",
+  "version": "0.3.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "opera-devtools-mcp",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/version.ts
+++ b/src/version.ts
@@ -8,5 +8,5 @@
 
 // If moved update release-please config
 // x-release-please-start-version
-export const VERSION = '0.2.6';
+export const VERSION = '0.3.0';
 // x-release-please-end


### PR DESCRIPTION
Bumps the package version to 0.3.0 to reflect the changes landed since 0.2.6 (fork modularization behind the upstream seam, the upstream intake with new tools such as PWA automation and multi-file upload, shared browser launch options, and dependency alignment with upstream).

Updated `package.json`, `package-lock.json`, `server.json`, and `src/version.ts`. No code changes.
