### PR TITLE
chore(release): align release-please-managed versions to 0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "opera-devtools-plugins",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Bundled plugins for automating Opera browsers, including Opera Neon, and their built-in AI features.",
   "repository": "https://github.com/operasoftware/opera-devtools-mcp",
   "owner": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "opera-devtools-mcp",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Automate Opera browsers, including Opera Neon, and their built-in AI features",
   "mcpServers": {
     "opera-devtools": {

--- a/.gitattributes
+++ b/.gitattributes
@@ -25,6 +25,7 @@ release-please-config.json             merge=opera-ours
 .release-please-manifest.json          merge=opera-ours
 src/version.ts                         merge=opera-ours
 .github/workflows/*                    merge=opera-ours
+.github/plugin/plugin.json             merge=opera-ours
 .claude-plugin/*                       merge=opera-ours
 
 # Generated artifacts: never hand-merge, always `npm run gen` after the merge.

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,12 +1,12 @@
 {
-  "name": "chrome-devtools-mcp",
-  "version": "1.7.0",
-  "description": "Reliable automation, in-depth debugging, and performance analysis in Chrome using Chrome DevTools and Puppeteer",
+  "name": "opera-devtools-mcp",
+  "version": "0.3.0",
+  "description": "Automate Opera browsers, including Opera Neon, and their built-in AI features",
   "mcpServers": {
-    "chrome-devtools": {
+    "opera-devtools": {
       "command": "npx",
       "args": [
-        "chrome-devtools-mcp@1.7.0"
+        "opera-devtools-mcp@0.3.0"
       ]
     }
   }

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -130,7 +130,7 @@ resolve by hand, keeping the Opera side.
 
 `README.md`, `CHANGELOG.md`, `.gitignore`, `.gitattributes`, `docs/troubleshooting.md`,
 `docs/UPSTREAM.md`, `package.json`, `server.json`, `.github/workflows/*`,
-`release-please-config.json`, `.release-please-manifest.json`, `src/version.ts`,
+`.github/plugin/plugin.json`, `release-please-config.json`, `.release-please-manifest.json`, `src/version.ts`,
 `.claude-plugin/*`, `NOTICE`.
 
 `src/version.ts` and `.release-please-manifest.json` carry the fork's own version line, which is


### PR DESCRIPTION
Adopts the release-please release flow (as upstream `chrome-devtools-mcp` uses it) and syncs every release-please-managed version file to `0.3.0`.

Following the confirmation that upstream actively drives releases with release-please (their manifest is in sync and their history is `chore(main): release ...`), this PR keeps release-please and makes its `extra-files` consistent so a future release-please run bumps correctly:

- `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`: `0.2.3` -> `0.3.0`.
- `.github/plugin/plugin.json`: this was upstream's GitHub/Copilot manifest pointing at the stale `chrome-devtools-mcp@1.7.0`. Adapted it to the fork's own package (`opera-devtools-mcp@0.3.0`, Opera branding) so it's consistent and release-please-managed.
- `.gitattributes` + `docs/UPSTREAM.md`: mark `.github/plugin/plugin.json` as `merge=opera-ours` (it now carries Opera-specific content, so a future upstream intake shouldn't clobber it).

`package.json`, `package-lock.json`, `server.json`, `src/version.ts` and `.release-please-manifest.json` are already at `0.3.0`. Verified: JSON valid, prettier-clean, `verify-upstream-seam` passes.

Note: the actual release workflow is unchanged — this PR only makes the release-please-managed version files consistent with the released `0.3.0`.
