### PR TITLE
ci: authenticate npm publish with NPM_TOKEN in publish-on-tag

### DIFF
--- a/.github/workflows/publish-to-npm-on-tag.yml
+++ b/.github/workflows/publish-to-npm-on-tag.yml
@@ -40,3 +40,5 @@ jobs:
       - name: Publish opera-devtools-mcp
         run: |
           npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The `publish-on-tag` workflow's `npm publish` step had no auth token, so npm rejected the upload (`E404`). `release-please.yml` works because it sets `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`. Mirror that here.