### PR TITLE
ci: align release-please workflow with upstream

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,39 +1,18 @@
-name: release-please
-
 on:
   push:
-    branches: [main]
+    branches:
+      - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+permissions: read-all
+name: release-please
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
-        id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.release_created }}
-
-      - uses: actions/setup-node@v6
-        if: ${{ steps.release.outputs.release_created }}
-        with:
-          node-version: 24
-          registry-url: 'https://registry.npmjs.org'
-
-      - run: npm ci
-        if: ${{ steps.release.outputs.release_created }}
-
-      - run: npm run build
-        if: ${{ steps.release.outputs.release_created }}
-
-      - run: npm publish --access public --provenance
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.BROWSER_AUTOMATION_BOT_TOKEN }}
+          target-branch: main
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Aligns the fork's `release-please.yml` with upstream's. The fork's version had drifted significantly:

- **Before**: fork ran release-please and then did the npm publish *inline* (`NODE_AUTH_TOKEN: secrets.NPM_TOKEN`), and used `secrets.GITHUB_TOKEN`.
- **After**: matches upstream — release-please just opens release PRs and cuts releases/tags; npm publishing is left to the `publish-on-tag` workflow (which now publishes via npm OIDC trusted publisher, no token needed). Added explicit `target-branch`, `config-file`, `manifest-file`.

This gives the fork one coherent release path (release-please cuts → `publish-on-tag` publishes), instead of two competing publishers.

## ⚠️ Action required before/around merge

The workflow now uses `secrets.BROWSER_AUTOMATION_BOT_TOKEN` (a **PAT**, matching upstream). This is **required** for the flow to work: when release-please cuts a release it creates a tag, and a tag created with `GITHUB_TOKEN` would **not** trigger `publish-on-tag` (GitHub doesn't fire workflows on `GITHUB_TOKEN` events). A PAT is needed so the release-please-created tag actually triggers the publish.

This secret must exist on the fork with `contents: write` (and the ability to push tags / open PRs). If it doesn't exist yet, please add it (`BROWSER_AUTOMATION_BOT_TOKEN`) — otherwise release-please will fail. If you already have a differently-named PAT secret, tell me and I'll swap the reference before merging.
