### PR TITLE
fix: add action type and toolName fields to MCP server/tool actions

### DIFF
--- a/src/opera/tools/opera.ts
+++ b/src/opera/tools/opera.ts
@@ -303,6 +303,7 @@ export const operaListMcpServers = definePageTool({
     try {
       const result = await dispatchAction(session, {
         action: 'listMcpServers',
+        type: 'LIST_SERVERS',
       });
       response.appendResponseLine(result);
     } catch (e) {
@@ -338,6 +339,7 @@ export const operaListMcpTools = definePageTool({
       const result = await dispatchAction(session, {
         action: 'listMcpTools',
         server: request.params.server,
+        type: 'LIST_TOOLS',
       });
       response.appendResponseLine(result);
     } catch (e) {
@@ -382,7 +384,8 @@ export const operaCallMcpTool = definePageTool({
       const payload: Record<string, unknown> = {
         action: 'callMcpTool',
         server: request.params.server,
-        tool: request.params.tool,
+        toolName: request.params.tool,
+        type: 'EXECUTE_TOOL',
       };
       if (request.params.parameters !== undefined) {
         payload['parameters'] = request.params.parameters;


### PR DESCRIPTION
Applies patch-1.txt: adds `type` fields to the MCP list servers/list tools/call tool actions and renames `tool` to `toolName` in the call action payload.