### PR TITLE
test: assert src/version.ts matches package.json

### DIFF
--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -69,6 +69,7 @@ a result:
 | `src/opera/tools/opera.ts`                                                                                                 | The five `opera_*` tools                                                                                   |
 | `src/map-extensions.d.ts`                                                                                                  | `Map.getOrInsert*` shims for chrome-devtools-frontend — **temporary**, drop when the TS lib has them       |
 | `tests/opera/opera.test.ts`                                                                                                | Unit coverage for the Opera tools                                                                          |
+| `tests/opera/version.test.ts`                                                                                              | Asserts `src/version.ts` matches `package.json` — a release must bump both                                 |
 | `src/bin/opera-devtools-mcp.ts`, `src/bin/opera-devtools.ts`                                                               | Opera-named bin entries (`package.json` `bin`); one-line `import` of the upstream file                     |
 | `src/bin/opera-devtools-mcp-cli-options.ts`, `src/bin/opera-devtools-cli-options.ts`, `src/bin/opera-devtools-mcp-main.ts` | Compatibility `export *` shims over the upstream files                                                     |
 

--- a/tests/opera/version.test.ts
+++ b/tests/opera/version.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2026 Opera Norway AS. All rights reserved.
+ *
+ * This file is an original work developed by Opera.
+ */
+
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import {describe, it} from 'node:test';
+
+import {VERSION} from '../../src/version.js';
+
+describe('VERSION', () => {
+  it('matches the version in package.json', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'),
+    );
+
+    // `npm ci` already fails when package-lock.json drifts from package.json,
+    // so src/version.ts is the only copy of the version nothing else checks.
+    // It is reported in the MCP handshake, by `--version`, and to the update
+    // checker, which compares it against the version published on npm — a
+    // stale one tells every user an update is available.
+    assert.strictEqual(
+      VERSION,
+      packageJson.version,
+      `src/version.ts is ${VERSION} but package.json is ${packageJson.version}; a release must bump both.`,
+    );
+  });
+});


### PR DESCRIPTION
`src/version.ts` carries the version separately from `package.json`, and nothing checked that the two agree.

The 0.4.1 release bumped `package.json`, `package-lock.json` and `server.json` but not `src/version.ts`, which stayed at `0.4.0`. That constant is not cosmetic:

| Use | Effect of a stale value |
| --- | --- |
| `src/index.ts` — MCP handshake `version` | clients were told 0.4.0 |
| `chrome-devtools.ts` — `.version(VERSION)` | `--version` printed 0.4.0 |
| `chrome-devtools.ts` — daemon/CLI match | spurious mismatch warning |
| `check-for-updates.ts` — `cachedVersion !== VERSION` | **every user saw "update available"**, since it compared npm's 0.4.1 against its own 0.4.0 |

`npm ci` already fails when `package-lock.json` drifts from `package.json`, so `src/version.ts` was the only copy nothing verified. This adds the missing assertion.

Verified non-vacuous — with `VERSION` set back to `0.4.0` against `package.json` 0.4.2:

```
AssertionError [ERR_ASSERTION]: src/version.ts is 0.4.0 but package.json is 0.4.2; a release must bump both.
✖ VERSION (1.161583ms)
```

The 0.4.2 bump on `main` (53f3133) already re-syncs the constant, so this is green on top of it.