### PR TITLE
feat: add conversationId param to operaChat tool

### DIFF
--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -646,6 +646,7 @@ in the DevTools Elements panel (if any).
 **Parameters:**
 
 - **prompt** (string) **(required)**: The prompt to send to Opera AI.
+- **conversationId** (string) _(optional)_: Conversation ID to continue an existing conversation. Omit to start a new conversation.
 - **model** (string) _(optional)_: Model ID to use for the chat. Omit to use the browser default. Use [`opera_list_models`](#opera_list_models) to discover available IDs.
 
 ---

--- a/src/bin/chrome-devtools-cli-options.ts
+++ b/src/bin/chrome-devtools-cli-options.ts
@@ -1061,6 +1061,13 @@ export const commands: Commands = {
           'Model ID to use for the chat. Omit to use the browser default. Use opera_list_models to discover available IDs.',
         required: false,
       },
+      conversationId: {
+        name: 'conversationId',
+        type: 'string',
+        description:
+          'Conversation ID to continue an existing conversation. Omit to start a new conversation.',
+        required: false,
+      },
     },
   },
   opera_connect_mcp_server: {

--- a/src/opera/tools/opera.ts
+++ b/src/opera/tools/opera.ts
@@ -119,6 +119,12 @@ export const operaChat = definePageTool({
       .describe(
         'Model ID to use for the chat. Omit to use the browser default. Use opera_list_models to discover available IDs.',
       ),
+    conversationId: zod
+      .string()
+      .optional()
+      .describe(
+        'Conversation ID to continue an existing conversation. Omit to start a new conversation.',
+      ),
   },
   handler: async (request, response) => {
     // puppeteer's _client() is internal; cast to the shape getCDPSession needs
@@ -132,6 +138,9 @@ export const operaChat = definePageTool({
       };
       if (request.params.model !== undefined) {
         payload['model'] = request.params.model;
+      }
+      if (request.params.conversationId !== undefined) {
+        payload['conversationId'] = request.params.conversationId;
       }
       const result = await dispatchAction(session, payload);
       response.appendResponseLine(result);

--- a/src/telemetry/tool_call_metrics.json
+++ b/src/telemetry/tool_call_metrics.json
@@ -669,6 +669,10 @@
       {
         "name": "model_length",
         "argType": "number"
+      },
+      {
+        "name": "conversation_id_length",
+        "argType": "number"
       }
     ]
   },

--- a/tests/opera/opera.test.ts
+++ b/tests/opera/opera.test.ts
@@ -201,6 +201,38 @@ describe('opera tools', () => {
       assert.match(lines[0]!, /Opera\.dispatchAction\(chat\) failed/);
       assert.match(lines[0]!, /boom/);
     });
+
+    it('forwards the conversationId when one is given', async () => {
+      const session = new FakeCDPSession();
+      const {response} = makeResponse();
+
+      await operaChat.handler(
+        makeRequest(session, {
+          prompt: 'hi',
+          conversationId: 'conversation-123',
+        }),
+        response,
+        context,
+      );
+
+      assert.strictEqual(
+        session.payloadAt(0)['conversationId'],
+        'conversation-123',
+      );
+    });
+
+    it('omits the conversationId key when none is given', async () => {
+      const session = new FakeCDPSession();
+      const {response} = makeResponse();
+
+      await operaChat.handler(
+        makeRequest(session, {prompt: 'hi'}),
+        response,
+        context,
+      );
+
+      assert.ok(!('conversationId' in session.payloadAt(0)));
+    });
   });
 
   describe('opera_make', () => {


### PR DESCRIPTION
Supports continuing an existing conversation by passing a conversationId. Omitting it starts a new conversation as before.